### PR TITLE
ramips: fix mmc driver (#3285)

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
@@ -2284,7 +2284,7 @@ static int msdc_drv_probe(struct platform_device *pdev)
 	host->mrq = NULL;
 	//init_MUTEX(&host->sem); /* we don't need to support multiple threads access */
 
-	mmc_dev(mmc)->dma_mask = NULL;
+	dma_coerce_mask_and_coherent(mmc_dev(mmc), DMA_BIT_MASK(32));
 
 	/* using dma_alloc_coherent*/  /* todo: using 1, for all 4 slots */
 	host->dma.gpd = dma_alloc_coherent(&pdev->dev,


### PR DESCRIPTION
Since commit f8c55dc ("MIPS: use generic dma noncoherent ops for
simple noncoherent platforms") changed MIPS dma handling, the mmc
driver fails because it doesn't have a dma mask is set.

So set the correct dma mask.

Signed-off-by: NeilBrown <neil@brown.name>
Signed-off-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>

Co-authored-by: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>